### PR TITLE
Add support for HTTPS in the development script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ next-env.d.ts
 
 # contentlayer
 .contentlayer
+
+certificates

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev-https": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
The experimental feature allowing access to HTTPS in a local environment was implemented in Next.js version 13.5. I have adapted Campanula to make use of this feature. https://nextjs.org/blog/next-13-5#other-improvements